### PR TITLE
#519 Updating Launcher to hold on to classloaders within a the same

### DIFF
--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/Launcher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/Launcher.java
@@ -41,7 +41,9 @@ import org.springframework.boot.loader.jar.JarFile;
 public abstract class Launcher {
 
 	protected Logger logger = Logger.getLogger(Launcher.class.getName());
-
+	
+	protected ClassLoader classLoader;
+	
 	/**
 	 * The main runner class. This must be loaded by the created ClassLoader so cannot be
 	 * directly referenced.
@@ -67,19 +69,27 @@ public abstract class Launcher {
 	}
 
 	/**
-	 * Create a classloader for the specified archives.
+	 * Create a classloader for the specified archives.  If previously called
+	 * it will return a cached classloader.
+	 * 
 	 * @param archives the archives
 	 * @return the classloader
 	 * @throws Exception
 	 */
 	protected ClassLoader createClassLoader(List<Archive> archives) throws Exception {
+		if (classLoader != null) {
+			return classLoader;
+		}
+		
 		List<URL> urls = new ArrayList<URL>(archives.size());
 		for (Archive archive : archives) {
 			// Add the current archive at end (it will be reversed and end up taking
 			// precedence)
 			urls.add(archive.getUrl());
 		}
-		return createClassLoader(urls.toArray(new URL[urls.size()]));
+		
+		classLoader = createClassLoader(urls.toArray(new URL[urls.size()]));
+		return classLoader;
 	}
 
 	/**

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/SharedJarLauncher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/SharedJarLauncher.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.loader;
+
+/**
+ * Singleton for {@link JarLauncher} so that multiple invocations of main in
+ * in the same JVM will return the same {@link JarLauncher} allowing for 
+ * possibility to issue more commands to application besides just 
+ * starting it (i.e. exit)
+ * 
+ * @author Andrew Wynham (DeezCashews)
+ *
+ */
+public class SharedJarLauncher extends JarLauncher {
+
+	protected static SharedJarLauncher INSTANCE;
+	
+	SharedJarLauncher() {
+	}
+	
+	public static final SharedJarLauncher getInstance() {
+		if (INSTANCE == null) {
+			INSTANCE = new SharedJarLauncher();
+		}
+		return INSTANCE;
+	}
+
+	public static void main(String[] args) {
+		getInstance().launch(args);
+	}
+}

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/SharedPropertiesLauncher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/SharedPropertiesLauncher.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.loader;
+
+/**
+ * Singleton for {@link PropertiesLauncher} so that multiple invocations of main in
+ * in the same JVM will return the same {@link PropertiesLauncher} allowing for 
+ * possibility to issue more commands to application besides just 
+ * starting it (i.e. exit)
+ * 
+ * @author Andrew Wynham (DeezCashews)
+ *
+ */
+public class SharedPropertiesLauncher extends PropertiesLauncher {
+
+	protected static SharedPropertiesLauncher INSTANCE;
+	
+	SharedPropertiesLauncher() {
+	}
+	
+	public static final SharedPropertiesLauncher getInstance() {
+		if (INSTANCE == null) {
+			INSTANCE = new SharedPropertiesLauncher();
+		}
+		return INSTANCE;
+	}
+
+	public static void main(String[] args) {
+		getInstance().launch(args);
+	}
+}

--- a/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/SharedWarLauncher.java
+++ b/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/SharedWarLauncher.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.loader;
+
+/**
+ * Singleton for {@link WarLauncher} so that multiple invocations of main in
+ * in the same JVM will return the same {@link WarLauncher} allowing for 
+ * possibility to issue more commands to application besides just 
+ * starting it (i.e. exit)
+ * 
+ * @author Andrew Wynham (DeezCashews)
+ *
+ */
+public class SharedWarLauncher extends WarLauncher {
+
+	protected static SharedWarLauncher INSTANCE;
+	
+	SharedWarLauncher() {
+	}
+	
+	public static final SharedWarLauncher getInstance() {
+		if (INSTANCE == null) {
+			INSTANCE = new SharedWarLauncher();
+		}
+		return INSTANCE;
+	}
+
+	public static void main(String[] args) {
+		getInstance().launch(args);
+	}
+}


### PR DESCRIPTION
instance of a launcher and then provided helper classes to act as
singletons for each of the 3 types of launchers, allowing for multiple
invocations of main with the same JVM to access the same classloader.
